### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.swp
+.env
+venv
+.venv
+*.pdf
+*.csv

--- a/.env_example
+++ b/.env_example
@@ -1,7 +1,7 @@
 #Log Level
 LOG_LEVEL = INFO
 
-LIGHTNING_RPC_FILE = /home/bitcoin/.lightning/bitcoin/lightning-rpc
+LIGHTNING_RPC_FILE = /data/lightning-rpc
 
 PAGE_TITLE = Boltcipher
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ uvicorn main:app --reload
 
 The HTML view is available at `http://localhost:8000/` by default. A JSON API is served under `/json/`.
 
+## Docker
+
+The application can also be started inside a Docker container. Build the image
+and run it with access to your Core Lightning RPC file:
+
+```bash
+docker build -t boltcipher .
+docker run -p 8000:8000 \
+    -v /path/to/lightning-rpc:/data/lightning-rpc \
+    --env-file .env boltcipher
+```
+
+Alternatively you can start the service using `docker-compose`:
+
+```bash
+docker compose up --build
+```
+
+The mount makes the RPC socket available inside the container as
+`/data/lightning-rpc`. Set `LIGHTNING_RPC_FILE=/data/lightning-rpc` in your
+`.env` file (see `.env_example`).
+
 ## Directory Structure
 
 - `main.py` – entry point of the FastAPI server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  boltcipher:
+    build: .
+    volumes:
+      - /path/to/lightning-rpc:/data/lightning-rpc
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose.yml
- ignore unnecessary files during Docker build
- adjust default RPC location in `.env_example`
- document running the server via Docker in README

## Testing
- `python -m py_compile main.py utils/cln.py helper/core-lightning-acess.py sandbox/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687b2a0d81e08333b5fdc505add4e874