### PR TITLE
Adjust host defaults for reverse proxy usage

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -10,6 +10,11 @@ PAGE_INFO = Boltcipher is a simple web application that allows you to create and
 #Content Price in Sats
 CONTENT_PRICE = 18
 
+APP_HOST = 0.0.0.0
+APP_PORT = 8000
+PROXY_HEADERS = True
+FORWARDED_ALLOW_IPS = '*'
+
 INVOICE_LABEL_PREFIX = f418
 
 INVOICE_DESCRIPTION = f418 test invoice

--- a/README.md
+++ b/README.md
@@ -26,16 +26,24 @@ The application reads its settings from environment variables (e.g. using an `.e
 - `LIGHTNING_RPC_FILE` – path to the RPC file of a Core Lightning node
 - `INVOICE_LABEL_PREFIX` – prefix for generated invoice labels
 - `INVOICE_DESCRIPTION` – description text for the created invoice
+- `APP_HOST` – IP address the server binds to (default `0.0.0.0`)
+- `APP_PORT` – port the server listens on (default `8000`)
+- `PROXY_HEADERS` – enable processing of proxy headers (default `True`)
+- `FORWARDED_ALLOW_IPS` – comma-separated list of IPs trusted as proxies (default `'*'`)
 
 ## Starting the Server
 
-After installation and configuration the server can be started with Uvicorn:
+After installation and configuration the server can be started with Uvicorn. When running behind a reverse proxy (e.g. Caddy), bind the application to `0.0.0.0` and enable proxy header support:
 
 ```bash
-uvicorn main:app --reload
+APP_HOST=0.0.0.0 \
+APP_PORT=8000 \
+PROXY_HEADERS=True \
+FORWARDED_ALLOW_IPS='*' \
+uvicorn main:app
 ```
 
-The HTML view is available at `http://localhost:8000/` by default. A JSON API is served under `/json/`.
+The HTML view is available on the configured host and port. A JSON API is served under `/json/`.
 
 ## Directory Structure
 

--- a/main.py
+++ b/main.py
@@ -103,7 +103,15 @@ async def get_info(request: Request):
 
 
 if __name__ == "__main__":
-    app_host = os.getenv("APP_HOST", "127.0.0.1")
+    app_host = os.getenv("APP_HOST", "0.0.0.0")
     app_port = int(os.getenv("APP_PORT", "8000"))
+    proxy_headers = os.getenv("PROXY_HEADERS", "True").lower() in {"true", "1", "yes"}
+    forwarded_allow_ips = os.getenv("FORWARDED_ALLOW_IPS", "*")
 
-    uvicorn.run(app, host=app_host, port=app_port)
+    uvicorn.run(
+        app,
+        host=app_host,
+        port=app_port,
+        proxy_headers=proxy_headers,
+        forwarded_allow_ips=forwarded_allow_ips,
+    )


### PR DESCRIPTION
## Summary
- bind server to `0.0.0.0` by default
- allow proxy headers and forwarded IPs in `uvicorn.run`
- document new settings in README
- update `.env_example` with host/port variables
- make proxy header support configurable

## Testing
- `python -m py_compile main.py config.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687b40c13dbc83339d90e594ad43f72f